### PR TITLE
Update to runitor v0.8.0 and simplify build stage

### DIFF
--- a/runitor/alpine/Dockerfile
+++ b/runitor/alpine/Dockerfile
@@ -1,14 +1,8 @@
 FROM golang:1-alpine AS builder
-ENV RUNITOR_VERSION 0.7.2
-ENV RUNITOR_GIT_TAG v$RUNITOR_VERSION
-RUN apk add --no-cache bash=~5 git=~2
-WORKDIR /tmp
-RUN git clone --depth 1 --branch $RUNITOR_GIT_TAG https://github.com/bdd/runitor.git
-WORKDIR /tmp/runitor
-RUN go build -o ./ ./cmd/runitor
-
+ARG RUNITOR_VERSION=v0.8.0
+RUN go install bdd.fi/x/runitor/cmd/runitor@${RUNITOR_VERSION:-latest}
 
 FROM alpine:3
 LABEL maintainer="Mark Caudill <mark@mrkc.me>"
-COPY --from=builder /tmp/runitor/runitor /usr/local/bin/runitor
+COPY --from=builder /go/bin/runitor /usr/local/bin
 CMD ["runitor"]

--- a/runitor/debian/Dockerfile
+++ b/runitor/debian/Dockerfile
@@ -1,14 +1,8 @@
 FROM golang:1-buster AS builder
-ENV RUNITOR_VERSION 0.7.2
-ENV RUNITOR_GIT_TAG v$RUNITOR_VERSION
-RUN apt-get update && apt-get install -y --no-install-recommends bash=5.* git=1:2.*
-WORKDIR /tmp
-RUN git clone --depth 1 --branch $RUNITOR_GIT_TAG https://github.com/bdd/runitor.git
-WORKDIR /tmp/runitor
-RUN go build -o ./ ./cmd/runitor
-
+ARG RUNITOR_VERSION=v0.8.0
+RUN go install bdd.fi/x/runitor/cmd/runitor@${RUNITOR_VERSION:-latest}
 
 FROM debian:buster
 LABEL maintainer="Mark Caudill <mark@mrkc.me>"
-COPY --from=builder /tmp/runitor/runitor /usr/local/bin/runitor
+COPY --from=builder /go/bin/runitor /usr/local/bin
 CMD ["runitor"]


### PR DESCRIPTION
Hi, I'm the author of runitor. I came across your Docker image for it on Docker Hub.

This PR updates the runitor version to the latest.

While I was there, I took the liberty to simplify the build stage of Dockerfiles.
Go tooling that comes with `golang` image allows single command fetch and compilation of specified versions, using Go Module Proxy, and enabling use of long term stable vanity import paths. This should make builds a tad faster too.

I also propose using `ARG` instead of `ENV` because runitor version is relied upon only at build time. You can build a new image for a specific version without changing the Dockerfile with `docker build --build-arg RUNITOR_VERSION=v0.7.2 .` or simply leave it empty to pull the symbolic `latest` version i.e. `docker build --build-arg RUNITOR_VERSION= .`